### PR TITLE
SYS-000 - Retrieve ALL RDS snapshots

### DIFF
--- a/app/rds.py
+++ b/app/rds.py
@@ -144,8 +144,7 @@ class RDS():
         # Get all snapshots for the account, which we will filter in the next step
         snapshots = self.client.describe_db_snapshots(
             DBInstanceIdentifier=target_rds_instance,
-            SnapshotType=snapshot_type,
-            MaxRecords=20
+            SnapshotType=snapshot_type
         )['DBSnapshots']
 
         #Filter to get only "Ready" snapshots


### PR DESCRIPTION
This script is used by various services (f.e. to create a personal dev DB or for ephemerals)
The AWS RDS API call to retrieve the snapshots from a DB identifier was limited to 20 results, preventing the latest snapshots to be discovered.
This PR will remove the `--max-items` to the query in order to get ALL snapshots from a desired instance