### PR TITLE
TUG-346 modify sleep after renaming instance

### DIFF
--- a/app/rds.py
+++ b/app/rds.py
@@ -366,7 +366,7 @@ class RDS():
                 NewDBInstanceIdentifier=new_identifier
             )
 
-            time.sleep(360)
+            time.sleep(600)
 
             return response
 


### PR DESCRIPTION
This PR is to fix a problem with data sync Confidant giving more time to do the modifications before launch the DNS change.